### PR TITLE
Fix reader mode link insertion context handling

### DIFF
--- a/main.js
+++ b/main.js
@@ -540,13 +540,13 @@ ${cleanExplanation}
 			return -1;
 		}
 
-		const matchesContext = (candidateIndex) => {
-			const beforeSlice = content.substring(Math.max(0, candidateIndex - (textBefore ? textBefore.length : 0)), candidateIndex).trim();
-			const afterSlice = content.substring(candidateIndex + selectedText.length, Math.min(content.length, candidateIndex + selectedText.length + (textAfter ? textAfter.length : 0))).trim();
-			const beforeMatch = !textBefore || beforeSlice.endsWith(textBefore);
-			const afterMatch = !textAfter || afterSlice.startsWith(textAfter);
-			return beforeMatch && afterMatch;
-		};
+                const matchesContext = (candidateIndex) => {
+                        const beforeSlice = content.substring(0, candidateIndex).trimEnd();
+                        const afterSlice = content.substring(candidateIndex + selectedText.length).trimStart();
+                        const beforeMatch = !textBefore || beforeSlice.endsWith(textBefore);
+                        const afterMatch = !textAfter || afterSlice.startsWith(textAfter);
+                        return beforeMatch && afterMatch;
+                };
 
 		let candidateIndex = content.indexOf(selectedText);
 		if (candidateIndex === -1) {


### PR DESCRIPTION
## Summary
- relax reader-mode context matching so the selected passage can be located even when trailing whitespace differs
- ensure explanation note links are inserted in reader mode without disrupting editor-mode behaviour

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cf7b6e3464832d9f4050d1764e381e