### PR TITLE
Allow configuring prompt template

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,9 @@ Access via Settings → Text Explainer:
 - **Note Directory**: Folder for created explanation notes (default: `Explanations`)
 - **Default properties & template**: Use the embedded editor to define front matter and Markdown defaults that every generated note will start from before you make per-note tweaks.
 
+#### Prompt Template
+- **Default prompt template**: Customize the instruction block that is sent to the language model when explaining short selections. You can reference placeholders such as `{{selectedText}}`, `{{language}}`, `{{paragraphText}}`, `{{textBefore}}`, `{{textAfter}}`, `{{contextSection}}`, `{{sampleSentenceLanguage}}`, `{{pronunciationHint}}`, and `{{noPinyinInstruction}}` to inject contextual details automatically.
+
 ### Note Configuration Modal
 
 Before saving a note you can tailor both the front matter and body directly from the explanation popup:

--- a/styles.css
+++ b/styles.css
@@ -185,6 +185,23 @@
     font-size: 0.85em;
 }
 
+.text-explainer-settings .prompt-template-settings {
+    margin-top: 16px;
+}
+
+.text-explainer-settings .prompt-template-control {
+    width: 100%;
+}
+
+.text-explainer-settings .prompt-template-control textarea {
+    width: 100%;
+    min-height: 200px;
+    font-family: var(--font-monospace);
+    font-size: 0.95em;
+    line-height: 1.4;
+    resize: vertical;
+}
+
 .text-explainer-modal .note-config-table,
 .text-explainer-settings .note-config-table {
     width: 100%;


### PR DESCRIPTION
## Summary
- add a configurable prompt template editor with placeholder helper text in the settings panel
- persist the prompt template in plugin settings and apply it when generating prompts
- document the new customization option and style the settings textarea for easier editing

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cf8a61e3cc832d9cd098f4ce47a4b4